### PR TITLE
feat(): add post start mechanisms for nomad, consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ You will find 3 kinds of nomad jobs in __examples/jobs__:
 * one with service provider consul, and connect native "true"
 * one with service provider consul, and connect with sidecar proxy "mesh"
 
-> Don't forget to activate in consul web, a global "intention allowing all to all"
-
 ```sh
 $ docker stats
 ```

--- a/examples/test.yaml
+++ b/examples/test.yaml
@@ -5,7 +5,7 @@ image:
   repository: 'ghcr.io/gperreymond/hashibase'
   tag: 'base-1.0.0'
 
-services:
-  nomad:
+plugins:
+  traefik:
     enabled: true
-    replicas: 1
+    version: '3.3.1'

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::{Command as ShellCommand, Stdio};
 use tera::{Context, Tera};
 
-// Embed the "templates" directory into the binary
+/// Embed the "templates" directory into the binary
 static TEMPLATES_DIR: Dir = include_dir!("src/templates");
 
 // Default output directory

--- a/src/templates/empty.yaml
+++ b/src/templates/empty.yaml
@@ -1,1 +1,46 @@
-services: {}
+{%- if services.nomad.enabled or services.consul.enabled %}
+services:
+  {%- if services.nomad.enabled %}
+  post-start-nomad:
+    image: 'bash:5.2.37'
+    container_name: 'post-start-nomad'
+    restart: unless-stopped
+    command: |
+      bash -c "
+        apk add curl > /dev/null 2>&1
+        sleep 60
+      "
+    volumes:
+      - './scripts:/scripts'
+    networks:
+      ministack: {}
+    depends_on:
+      {%- for i in range(start=1, end=services.nomad.replicas+1) %}
+      'nomad-server-{{ i }}':
+        condition: service_healthy
+      {%- endfor %}
+  {%- endif %}
+  {%- if services.consul.enabled %}
+  post-start-consul:
+    image: 'bash:5.2.37'
+    container_name: 'post-start-consul'
+    restart: unless-stopped
+    command: |
+      bash -c "
+        apk add curl > /dev/null 2>&1
+        echo ""
+        bash /scripts/consul/01-apply-default-intension.sh
+        bash /scripts/consul/02-register-traefik.sh
+        sleep 60
+      "
+    volumes:
+      - './scripts:/scripts'
+    networks:
+      ministack: {}
+    depends_on:
+      {%- for i in range(start=1, end=services.consul.replicas+1) %}
+      'consul-server-{{ i }}':
+        condition: service_healthy
+      {%- endfor %}
+  {%- endif %}
+{%- endif %}

--- a/src/templates/plugins/traefik.yaml
+++ b/src/templates/plugins/traefik.yaml
@@ -5,6 +5,7 @@ services:
     container_name: 'traefik'
     command:
       - '--log.level={%- if plugins.traefik.log_level -%}{{ plugins.traefik.log_level }}{%- else -%}INFO{%- endif -%}'
+      - '--ping=true'
       - '--api.insecure=true'
       - '--metrics.prometheus.entryPoint=metrics'
       - '--metrics.prometheus=true'
@@ -48,12 +49,14 @@ services:
     depends_on:
       {%- if services.nomad.enabled %}
       {%- for i in range(start=1, end=services.nomad.replicas+1) %}
-      - 'nomad-server-{{ i }}'
+      'nomad-server-{{ i }}':
+        condition: service_healthy
       {%- endfor %}
       {%- endif %}
       {%- if services.consul.enabled %}
       {%- for i in range(start=1, end=services.consul.replicas+1) %}
-      - 'consul-server-{{ i }}'
+      'consul-server-{{ i }}':
+        condition: service_healthy
       {%- endfor %}
       {%- endif %}
     {%- endif %}

--- a/src/templates/scripts/consul/01-apply-default-intension.sh
+++ b/src/templates/scripts/consul/01-apply-default-intension.sh
@@ -1,0 +1,16 @@
+# Variables
+CONSUL_HOST="http://10.1.0.101:8500"
+SERVICE_NAME="default%2Fdefault%2F*"
+DESTINATION_SERVICE="default%2Fdefault%2F*"
+
+echo "===== apply default intension ====="
+
+# Step 1: Create or update the intention
+echo "[INFO] creating/updating intention for $SERVICE_NAME to communicate with $DESTINATION_SERVICE..."
+curl  --silent --request PUT \
+      --data "{
+        \"Action\": \"deny\"
+      }" \
+      "$CONSUL_HOST/v1/connect/intentions/exact?source=$SERVICE_NAME&destination=$DESTINATION_SERVICE" > /dev/null 2>&1
+echo "[INFO] intention created/updated."
+echo ""

--- a/src/templates/scripts/consul/02-register-traefik.sh
+++ b/src/templates/scripts/consul/02-register-traefik.sh
@@ -1,0 +1,45 @@
+# Variables
+CONSUL_HOST="http://10.1.0.101:8500"
+SERVICE_NAME="traefik"
+SERVICE_ID="traefik-1"
+SERVICE_ADDRESS="10.1.0.10"
+SERVICE_PORT=8080
+HEALTH_CHECK_URL="http://10.1.0.10:8080/ping"
+DESTINATION_SERVICE="*"
+
+echo "===== register traefik ====="
+
+# Step 1: Deregister the service (ignore errors if the service doesn't exist)
+echo "[INFO] attempting to deregister service $SERVICE_ID..."
+curl --silent --request PUT "$CONSUL_HOST/v1/agent/service/deregister/$SERVICE_ID" || true
+echo "[INFO] service $SERVICE_ID deregistered if it existed, continuing..."
+
+# Step 2: Register the service
+echo "[INFO] registering service $SERVICE_NAME..."
+curl  --silent --request PUT \
+      --data "{
+        \"Name\": \"$SERVICE_NAME\",
+        \"ID\": \"$SERVICE_ID\",
+        \"Address\": \"$SERVICE_ADDRESS\",
+        \"Port\": $SERVICE_PORT,
+        \"Connect\": {
+          \"SidecarService\": {}
+        },
+        \"Check\": {
+          \"HTTP\": \"$HEALTH_CHECK_URL\",
+          \"Interval\": \"10s\",
+          \"Timeout\": \"1s\"
+        }
+      }" \
+      "$CONSUL_HOST/v1/agent/service/register" > /dev/null 2>&1
+echo "[INFO] service $SERVICE_NAME registered."
+
+# Step 3: Create or update the intention
+echo "[INFO] creating/updating intention for $SERVICE_NAME to communicate with $DESTINATION_SERVICE..."
+curl  --silent --request PUT \
+      --data "{
+        \"Action\": \"allow\"
+      }" \
+      "$CONSUL_HOST/v1/connect/intentions/exact?source=$SERVICE_NAME&destination=$DESTINATION_SERVICE" > /dev/null 2>&1
+echo "[INFO] intention created/updated."
+echo ""

--- a/src/templates/services/consul.yaml
+++ b/src/templates/services/consul.yaml
@@ -10,6 +10,12 @@ services:
       - command: 'start-ministack'
     pre_stop:
       - command: 'service consul stop'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://10.1.0.10{{ i }}:8500/v1/status/leader"]
+      interval: 30s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
     environment:
       MINISTACK: 'true'
       {%- if services.consul.version %}

--- a/src/templates/services/nomad-clients.yaml
+++ b/src/templates/services/nomad-clients.yaml
@@ -38,12 +38,14 @@ services:
     depends_on:
       {%- if services.nomad.enabled %}
       {%- for i in range(start=1, end=services.nomad.replicas+1) %}
-      - 'nomad-server-{{ i }}'
+      'nomad-server-{{ i }}':
+        condition: service_healthy
       {%- endfor %}
       {%- endif %}
       {%- if services.consul.enabled %}
       {%- for i in range(start=1, end=services.consul.replicas+1) %}
-      - 'consul-server-{{ i }}'
+      'consul-server-{{ i }}':
+        condition: service_healthy
       {%- endfor %}
       {%- endif %}
   {%- endfor %}

--- a/src/templates/services/nomad.yaml
+++ b/src/templates/services/nomad.yaml
@@ -13,6 +13,10 @@ services:
       {%- if services.consul.enabled %}
       - command: 'service consul stop'
       {%- endif %}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://10.1.0.20{{ i }}:4646/v1/status/leader"]
+      interval: 30s
+      retries: 5
     environment:
       MINISTACK: 'true'
       {%- if services.nomad.version %}
@@ -45,7 +49,8 @@ services:
     {%- if services.consul.enabled %}
     depends_on:
       {%- for i in range(start=1, end=services.consul.replicas+1) %}
-      - 'consul-server-{{ i }}'
+      'consul-server-{{ i }}':
+        condition: service_healthy
       {%- endfor %}
     {%- endif %}
   {%- endfor %}


### PR DESCRIPTION
**the post start mechanisms:**

the concept is to have docker container waiting for healthy nomad and consul services.
then, execute scripts every 60s, to be sure no one destroy somethings in webui.

**the firsts ones, are for consul:**

* add an intention deny all
* add traefik service, to have traefik in the mesh, and his consul intention